### PR TITLE
Fix cli packaging

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var R = require('ramda');
 
 var program = require('commander');
 
-console.log('SNTH', process.argv);
-
 program
     .version('0.0.1')
     .option('-s, --seed [seed]', 'seed for the random number generator')
@@ -18,8 +16,6 @@ program
 
         var result = null;
         var error = null;
-        console.log('generator: ', generator);
-        console.log('args: ', args);
         var options = require('minimist')(program.rawArgs.slice(3), { string: 'pool' });
 
         // Note, this is potentially dangerous as it prevents users from having

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": "chancejs/chancejs-cli",
   "bin": {
-    "chance": "./chance.js"
+    "chance": "./index.js"
   },
   "preferGlobal": true,
   "keywords": [


### PR DESCRIPTION
Also removed redundant `console.log` calls because it clutters the output (doesn't match examples and can't be used with `pbcopy`)

There are also no tests so I only tested a couple generators manually on OS X 10.11.4 and Ubuntu 15.10 with the latest version of NodeJS.

This is a solution to issue https://github.com/chancejs/chance-cli/issues/2